### PR TITLE
Add XML doc generation

### DIFF
--- a/src/FSharp.NET.Sdk/build/FSharp.NET.Core.Sdk.targets
+++ b/src/FSharp.NET.Sdk/build/FSharp.NET.Core.Sdk.targets
@@ -99,6 +99,7 @@ this file.
             <DotnetCompileFscResponseLines Include="--out:$(_IntermediateOutputPathFull)$(TargetName)$(TargetExt)" />
 
             <DotnetCompileFscResponseLines Condition="'$(OutputType)' == 'Exe'"  Include="--emit-entry-point:True" />
+            <DotnetCompileFscResponseLines Condition="'$(GenerateDocumentationFile)' == 'true'" Include="--generate-xml-documentation:True" />
 
             <!--DOC: $(DefineConstants) is a string separated by ';' so let's convert to array-->
             <DefineConstantsArray Include="$(DefineConstants.Split(';'))" />


### PR DESCRIPTION
Adds a line to the `fsc` response file that will trigger the compiler to generate XML documentation when `GenerateDocumentationFile` is set to true.

As a workaround, the line can be added directly to an `fsproj` file to generate documentation. Including it in the standard F# targets makes more sense, though.