### PR TITLE
Fix msbuild (full)

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <FSharpNETSdkVersion>1.0.2</FSharpNETSdkVersion>
+    <FSharpNETSdkVersion>1.0.3</FSharpNETSdkVersion>
     <FSharpSdkVersion>1.0.0</FSharpSdkVersion>
   </PropertyGroup>
 

--- a/src/FSharp.NET.Sdk/build/FSharp.NET.Core.Sdk.targets
+++ b/src/FSharp.NET.Sdk/build/FSharp.NET.Core.Sdk.targets
@@ -155,13 +155,13 @@ this file.
             <_DotNetHostExecutablePath>$(_DotNetHostExecutableDirectory)/$(_DotNetHostExecutableName)</_DotNetHostExecutablePath>
         </PropertyGroup>
 
-        <PropertyGroup Condition=" '$(DontRunFscWithDotnet)' == '' ">
+        <PropertyGroup Condition=" $(FscToolExe.EndsWith('.exe')) == false ">
             <_FscTask_FscToolExe>$(_DotNetHostExecutableName)</_FscTask_FscToolExe>
             <_FscTask_FscToolPath>$(_DotNetHostExecutableDirectory)</_FscTask_FscToolPath>
             <_FscTask_DotnetFscCompilerPath> "$(FscToolPath)/$(FscToolExe)"</_FscTask_DotnetFscCompilerPath>
         </PropertyGroup>
 
-        <PropertyGroup Condition=" '$(DontRunFscWithDotnet)' != '' "> <!-- check fsc extension? -->
+        <PropertyGroup Condition=" $(FscToolExe.EndsWith('.exe')) == true ">
             <_FscTask_FscToolExe>$(FscToolExe)</_FscTask_FscToolExe>
             <_FscTask_FscToolPath>$(FscToolPath)</_FscTask_FscToolPath>
             <_FscTask_DotnetFscCompilerPath></_FscTask_DotnetFscCompilerPath>


### PR DESCRIPTION
If `FscToolExe` has `.exe` extensions, is a .net full app, so call it as `fsc.exe`.
Otherwise, like when `fsc.dll`, as `dotnet fsc.dll`
