### PR TITLE
use guid of for new roslyn project system

### DIFF
--- a/src/FSharp.NET.Sdk/build/FSharp.NET.Sdk.props
+++ b/src/FSharp.NET.Sdk/build/FSharp.NET.Sdk.props
@@ -19,7 +19,7 @@ WARNING:  You CAN MODIFY this file, doesnt matter if you are not knowledgeable a
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 
     <!-- project guid used by dotnet sln add -->
-    <DefaultProjectTypeGuid Condition=" '$(DefaultProjectTypeGuid)' == '' ">{F2A71F9B-5D33-465A-A702-920D77279786}</DefaultProjectTypeGuid>
+    <DefaultProjectTypeGuid Condition=" '$(DefaultProjectTypeGuid)' == '' ">{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}</DefaultProjectTypeGuid>
 
     <FSharpLanguageTargets>$(MSBuildThisFileDirectory)\FSharp.NET.Current.Sdk.targets</FSharpLanguageTargets>
   </PropertyGroup>


### PR DESCRIPTION
use new guid `6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705` for fsproj (for sln files), to use new roslyn project system.

this works on `dotnet sln` command too, if the project is already restored

ref https://github.com/dotnet/roslyn-project-system/pull/1670#issuecomment-289982834

/cc @srivatsn @brettfo @KevinRansom i'll release it with `1.0.3`
