### PR TITLE
use .proj extension

### DIFF
--- a/build/Build.targets
+++ b/build/Build.targets
@@ -3,26 +3,25 @@
     <Target Name="Package"
             DependsOnTargets="RestoreSrcPackages">
 
-        <Exec Command='dotnet pack --no-build --output $(ArtifactsDir)/nupkgs /p:Version=$(FSharpSdkVersion)' 
-              WorkingDirectory="$(RepoRoot)/src/FSharp.Sdk"/>
+        <Exec Command='dotnet pack $(RepoRoot)/src/FSharp.Sdk/FSharp.Sdk.proj --output $(ArtifactsDir)/nupkgs /p:Version=$(FSharpSdkVersion)' />
 
-        <Exec Command='dotnet pack --no-build --output $(ArtifactsDir)/nupkgs /p:Version=$(FSharpNETSdkVersion)' 
-              WorkingDirectory="$(RepoRoot)/src/FSharp.NET.Sdk"/>
+        <Exec Command='dotnet pack $(RepoRoot)/src/FSharp.NET.Sdk/FSharp.NET.Sdk.proj --output $(ArtifactsDir)/nupkgs /p:Version=$(FSharpNETSdkVersion)' />
+
     </Target>
 
     <Target Name="SetupRestoreSrcPackagesInputsOutputs">
         <!-- List of test projects to restore -->
 
         <ItemGroup>
-            <RestoreSrcPackagesInput Include="$(RepoRoot)/src/FSharp.NET.Sdk/FSharp.NET.Sdk.csproj" />
-            <RestoreSrcPackagesInput Include="$(RepoRoot)/src/FSharp.Sdk/FSharp.Sdk.csproj" />
+            <RestoreSrcPackagesInput Include="$(RepoRoot)/src/FSharp.NET.Sdk/FSharp.NET.Sdk.proj" />
+            <RestoreSrcPackagesInput Include="$(RepoRoot)/src/FSharp.Sdk/FSharp.Sdk.proj" />
         </ItemGroup>
     </Target>
 
     <Target Name="RestoreSrcPackages"
             DependsOnTargets="SetupRestoreSrcPackagesInputsOutputs"
             Inputs="@(RestoreSrcPackagesInput)"
-            Outputs="@(RestoreSrcPackagesInput->'%(RelativeDir)/obj/project.assets.json');@(RestoreSrcPackagesInput->'%(RelativeDir)/obj/%(Filename).csproj.nuget.g.props')">
+            Outputs="@(RestoreSrcPackagesInput->'%(RelativeDir)/obj/project.assets.json');@(RestoreSrcPackagesInput->'%(RelativeDir)/obj/%(Filename)%(Extension).nuget.g.props')">
         <!-- Restore test projects, if needed (with lock files up-to-date check) -->
 
         <Exec Command='dotnet restore %(RestoreSrcPackagesInput.FullPath) --packages $(NuGetPackageRoot) --no-cache -v n' />

--- a/src/FSharp.NET.Sdk/FSharp.NET.Sdk.proj
+++ b/src/FSharp.NET.Sdk/FSharp.NET.Sdk.proj
@@ -3,12 +3,10 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.3;net40</TargetFramework>
 
-    <AssemblyName>FSharp.NET.Sdk</AssemblyName>
-
     <PackageId>FSharp.NET.Sdk</PackageId>
     <Authors>Enrico Sada</Authors>
     <Description>F# and .NET Core SDK working together</Description>
-    <PackageReleaseNotes>Compatible with .NET Core Sdk 1.0.0-rc4</PackageReleaseNotes>
+    <PackageReleaseNotes>Compatible with .NET Core Sdk 1.0.1</PackageReleaseNotes>
     <PackageTags>f#;sdk;fsharp;msbuild</PackageTags>
     <PackageProjectUrl>https://github.com/dotnet/netcorecli-fsc</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
@@ -16,6 +14,8 @@
 
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <PackProjectInputFile>$(MSBuildProjectFullPath)</PackProjectInputFile>
+    <NoBuild>true</NoBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FSharp.Sdk/FSharp.Sdk.proj
+++ b/src/FSharp.Sdk/FSharp.Sdk.proj
@@ -16,6 +16,8 @@
 
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <PackProjectInputFile>$(MSBuildProjectFullPath)</PackProjectInputFile>
+    <NoBuild>true</NoBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
fix #97

remove the use of .csproj extension, because projects are just used for creating nupkg
