### PR TITLE
split package in dependency and bundled

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -31,7 +31,7 @@
 
   <PropertyGroup>
     <FSharpNETSdkVersion>1.0.3</FSharpNETSdkVersion>
-    <FSharpSdkVersion>1.0.0</FSharpSdkVersion>
+    <FSharpSdkVersion>$(FSharpNETSdkVersion)-bundled</FSharpSdkVersion>
   </PropertyGroup>
 
   <Target Name="BuildTheWholeCli"

--- a/build/Test.targets
+++ b/build/Test.targets
@@ -24,7 +24,7 @@ dotnet test -c $(Configuration) --logger trx
         </PropertyGroup>
 
         <ItemGroup>
-            <_NupkgsToTest Include="$(ArtifactsDir)/nupkgs/FSharp.Sdk.$(FSharpSdkVersionToTest).nupkg" />
+            <_NupkgsToTest Include="$(ArtifactsDir)/nupkgs/FSharp.NET.Sdk.$(FSharpSdkVersionToTest).nupkg" />
             <_NupkgsToTest Include="$(ArtifactsDir)/nupkgs/FSharp.NET.Sdk.$(FSharpNETSdkVersionToTest).nupkg" />
         </ItemGroup>
 
@@ -35,7 +35,6 @@ dotnet test -c $(Configuration) --logger trx
               DestinationFolder="$(RepoRoot)/test/packagesToTest" />
 
         <!--Remove nupkgs from test suite cache-->
-        <RemoveDir Directories="$(RepoRoot)/test/packages/fsharp.sdk" />
         <RemoveDir Directories="$(RepoRoot)/test/packages/fsharp.net.sdk" />
         <RemoveDir Directories="$(RepoRoot)/test/packages/dotnet-compile-fsc" />
     </Target>

--- a/src/FSharp.Sdk/FSharp.Sdk.proj
+++ b/src/FSharp.Sdk/FSharp.Sdk.proj
@@ -3,12 +3,10 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
 
-    <AssemblyName>FSharp.Sdk</AssemblyName>
-
-    <PackageId>FSharp.Sdk</PackageId>
+    <PackageId>FSharp.NET.Sdk</PackageId>
     <Authors>Enrico Sada</Authors>
     <Description>SDK for F# bundled inside .NET Core SDK</Description>
-    <PackageReleaseNotes>Compatible with .NET Core Sdk 1.0.0-rc4</PackageReleaseNotes>
+    <PackageReleaseNotes>Compatible with .NET Core Sdk 1.0.1</PackageReleaseNotes>
     <PackageTags>f#;sdk;fsharp;msbuild</PackageTags>
     <PackageProjectUrl>https://github.com/dotnet/netcorecli-fsc</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
The `-bundled` should be included in the `Sdks` directory of VS/mono/.NET Core Sdk
the normal is to be used a dependency inside fsproj

fix #56 
