### PR TITLE
fix errors on msbuild without restore

### DIFF
--- a/src/FSharp.Sdk/Sdk/Sdk.targets
+++ b/src/FSharp.Sdk/Sdk/Sdk.targets
@@ -15,6 +15,18 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
+  <Target Name="CreateManifestResourceNames">
+    <!-- the CreateManifestResourceNames target is required.
+         Will be overriden in restored FSharp.NET.Sdk  -->
+    <Warning Text="The 'CreateManifestResourceNames' target should be overriden in 'FSharp.NET.Sdk' package. Maybe you need to add 'FSharp.NET.Sdk' package to fsproj or run restore" />
+  </Target>
+
+  <Target Name="CoreCompile">
+    <!-- the CoreCompile target is required.
+         Will be overriden in restored FSharp.NET.Sdk  -->
+    <Warning Text="The 'CoreCompile' target should be overriden in 'FSharp.NET.Sdk' package. Maybe you need to add 'FSharp.NET.Sdk' package to fsproj or run restore" />
+  </Target>
+
   <PropertyGroup Condition=" '$(LanguageTargets)' == '' and '$(MSBuildProjectExtension)' == '.fsproj' ">
 
     <!-- On restore -->


### PR DESCRIPTION
the `CreateManifestResourceNames` is required but is implemented in restored `FSharp.NET.Sdk`, so the
msbuild fails, if is not restored.

Also `CoreCompile` with .net core sdk 2.0

these targerts will be overridden by targets inside restored `FSharp.NET.Sdk` package